### PR TITLE
Update npm publish action

### DIFF
--- a/.github/workflows/dry_run_npm_payments_mcp.yml
+++ b/.github/workflows/dry_run_npm_payments_mcp.yml
@@ -1,15 +1,11 @@
-name: Dry Run NPM Publish
+name: Verify Package
 
 on:
+  pull_request:
+    branches: [main]
   workflow_dispatch:
-    inputs:
-      version:
-        description: 'Version to test (e.g., v1.0.0)'
-        required: true
-        type: string
 
 permissions:
-  id-token: write # Required for OIDC trusted publishing
   contents: read
 
 jobs:
@@ -41,7 +37,7 @@ jobs:
       - name: Build project
         run: npm run build
 
-  dry-run:
+  verify-package:
     needs: test
     runs-on: ubuntu-latest
 
@@ -56,56 +52,40 @@ jobs:
           cache: 'npm'
           registry-url: 'https://registry.npmjs.org'
 
-      - name: Update npm to latest
-        run: npm install -g npm@latest
-
-      - name: Configure npm for trusted publishing
-        run: |
-          npm config delete always-auth 2>/dev/null || true
-
       - name: Install dependencies
         run: npm ci
 
       - name: Build project
         run: npm run build
 
-      - name: Extract version from input
+      - name: Get current version
         id: version
         run: |
-          VERSION=${{ github.event.inputs.version }}
-          VERSION=${VERSION#v}
+          VERSION=$(node -p "require('./package.json').version")
           echo "version=$VERSION" >> $GITHUB_OUTPUT
-          echo "Testing version: $VERSION"
-
-      - name: Update package.json version
-        run: |
-          npm version ${{ steps.version.outputs.version }} --no-git-tag-version
+          echo "Current version: $VERSION"
 
       - name: Verify package contents
         run: |
-          echo "Package contents:"
+          echo "📦 Package contents preview:"
           npm pack --dry-run
 
-      - name: Dry Run NPM Publish
+      - name: Verify publish readiness
         run: |
-          echo "🧪 Running dry run publish..."
+          echo "🧪 Verifying package can be published..."
           npm publish --dry-run --access public
-          echo "✅ Dry run completed successfully!"
-          echo ""
-          echo "📦 Package would be published as: @coinbase/payments-mcp@${{ steps.version.outputs.version }}"
-          echo "🎯 Install command would be: npx @coinbase/payments-mcp@${{ steps.version.outputs.version }}"
+          echo "✅ Package verification successful!"
 
-      - name: Generate publish summary
+      - name: Generate summary
         run: |
-          echo "## 🧪 Dry Run Summary" >> $GITHUB_STEP_SUMMARY
+          echo "## ✅ Package Verification" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "✅ All checks passed! Package is ready for publishing." >> $GITHUB_STEP_SUMMARY
+          echo "All checks passed! Package is ready for publishing." >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**Package:** \`@coinbase/payments-mcp@${{ steps.version.outputs.version }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "**Current version:** \`${{ steps.version.outputs.version }}\`" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**Install command:**" >> $GITHUB_STEP_SUMMARY
+          echo "**To publish a new release:**" >> $GITHUB_STEP_SUMMARY
           echo "\`\`\`bash" >> $GITHUB_STEP_SUMMARY
-          echo "npx @coinbase/payments-mcp@${{ steps.version.outputs.version }}" >> $GITHUB_STEP_SUMMARY
+          echo "npm version patch  # or minor/major" >> $GITHUB_STEP_SUMMARY
+          echo "git push --follow-tags" >> $GITHUB_STEP_SUMMARY
           echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "To publish for real, run the **Deploy to NPM** workflow." >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/publish_npm_payments_mcp.yml
+++ b/.github/workflows/publish_npm_payments_mcp.yml
@@ -1,12 +1,9 @@
 name: Deploy to NPM
 
 on:
-  workflow_dispatch:
-    inputs:
-      version:
-        description: 'Version to deploy (e.g., v1.0.0)'
-        required: true
-        type: string
+  push:
+    tags:
+      - 'v*.*.*'  # Triggers on version tags like v1.0.0, v2.1.3, etc.
 
 permissions:
   id-token: write # Required for OIDC trusted publishing
@@ -70,17 +67,22 @@ jobs:
       - name: Build project
         run: npm run build
 
-      - name: Extract version from input
+      - name: Extract version from tag
         id: version
         run: |
-          VERSION=${{ github.event.inputs.version }}
-          VERSION=${VERSION#v}
+          VERSION=${GITHUB_REF#refs/tags/v}
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "Deploying version: $VERSION"
 
-      - name: Update package.json version
+      - name: Verify package.json version matches tag
         run: |
-          npm version ${{ steps.version.outputs.version }} --no-git-tag-version
+          PACKAGE_VERSION=$(node -p "require('./package.json').version")
+          TAG_VERSION=${{ steps.version.outputs.version }}
+          if [ "$PACKAGE_VERSION" != "$TAG_VERSION" ]; then
+            echo "Error: package.json version ($PACKAGE_VERSION) doesn't match tag version ($TAG_VERSION)"
+            exit 1
+          fi
+          echo "Version verified: $PACKAGE_VERSION"
 
       - name: Verify package contents
         run: npm pack --dry-run

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,31 +57,6 @@ src/
    npm run dev
    ```
 
-## Development Commands
-
-```bash
-# Install dependencies
-npm install
-
-# Build TypeScript
-npm run build
-
-# Test locally
-npm run dev
-
-# Run tests
-npm test
-
-# Run linting
-npm run lint
-
-# Format code
-npm run format
-
-# Watch mode for development
-npm run dev:watch
-```
-
 ## Pull Request Workflow
 
 1. **Create a Feature Branch**
@@ -157,6 +132,46 @@ Signed commits are required for all contributions. Follow these steps:
    ```
 
 For more details, see [GitHub's documentation on signing commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
+
+## Publishing New Versions
+
+This project uses a standard tag-based release workflow. To publish a new version:
+
+### 1. Bump the version
+
+Use npm's built-in version command to update `package.json` and create a git tag:
+
+```bash
+# For bug fixes (1.0.0 → 1.0.1)
+npm version patch
+
+# For new features (1.0.0 → 1.1.0)
+npm version minor
+
+# For breaking changes (1.0.0 → 2.0.0)
+npm version major
+```
+
+This automatically:
+- Updates `package.json` and `package-lock.json`
+- Creates a git commit with the version change
+- Creates a git tag (e.g., `v1.0.1`)
+
+### 2. Push the tag
+
+```bash
+git push && git push --tags
+```
+
+### 3. Automatic deployment
+
+Once the tag is pushed, the GitHub Actions workflow will automatically:
+- Run tests and linting
+- Build the project
+- Verify the version matches the tag
+- Publish to NPM with provenance
+
+**Note**: The workflow only triggers on tags matching the pattern `v*.*.*` (e.g., `v1.0.0`, `v2.1.3`).
 
 ## Code Guidelines
 

--- a/README.md
+++ b/README.md
@@ -168,6 +168,46 @@ CLI Command → Orchestrator  →  Services →  Utilities
    - Display client-specific setup instructions
    - Provide config file locations and troubleshooting information
 
+## Publishing New Versions
+
+This project uses a standard tag-based release workflow. To publish a new version:
+
+### 1. Bump the version
+
+Use npm's built-in version command to update `package.json` and create a git tag:
+
+```bash
+# For bug fixes (1.0.0 → 1.0.1)
+npm version patch
+
+# For new features (1.0.0 → 1.1.0)
+npm version minor
+
+# For breaking changes (1.0.0 → 2.0.0)
+npm version major
+```
+
+This automatically:
+- Updates `package.json` and `package-lock.json`
+- Creates a git commit with the version change
+- Creates a git tag (e.g., `v1.0.1`)
+
+### 2. Push the tag
+
+```bash
+git push && git push --tags
+```
+
+### 3. Automatic deployment
+
+Once the tag is pushed, the GitHub Actions workflow will automatically:
+- Run tests and linting
+- Build the project
+- Verify the version matches the tag
+- Publish to NPM with provenance
+
+**Note**: The workflow only triggers on tags matching the pattern `v*.*.*` (e.g., `v1.0.0`, `v2.1.3`).
+
 ## Troubleshooting
 
 ### Common Issues

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # @coinbase/payments-mcp
 
-A TypeScript-based npx installer for the payments-mcp project, providing seamless integration with stdio-compatible MCP clients for cryptocurrency payments functionality.
+A TypeScript-based npx installer for the payments-mcp project, providing seamless integration with stdio-compatible MCP clients for  agentic payments via x402 and the x402 Bazaar.
 
 ## Quick Start
 
@@ -13,30 +13,15 @@ npx @coinbase/payments-mcp
 ### 2) Select your MCP client:
 
 During installation, you'll be prompted to choose which MCP client you're configuring:
-- **Claude Desktop** - Claude Desktop application
+- **Claude** - Claude Desktop application
 - **Claude Code** - Claude Code CLI
-- **Codex CLI** - OpenAI Codex CLI
-- **Google Gemini CLI** - Google Gemini CLI
+- **Codex** - OpenAI Codex CLI
+- **Gemini** - Google Gemini CLI
 - **Other** - Other MCP-compatible tools
-
-You can also specify the client directly:
-
-```bash
-npx @coinbase/payments-mcp --client <client>
-```
 
 ### 3) Automatic Configuration (Optional):
 
-The installer supports **automatic configuration** for compatible MCP clients:
-
-**File-based (e.g. Claude Desktop):**
-- Automatically creates or updates the configuration file
-- Merges with existing MCP servers without overwriting
-- Backs up malformed configs before fixing
-
-**CLI-based (e.g. Claude Code, Codex, Gemini):**
-- Executes the client's configuration CLI command
-- Automatically adds payments-mcp using the client's native tools
+The installer supports **automatic configuration** for compatible MCP clients.
 
 You'll be prompted during installation, or you can:
 
@@ -58,7 +43,7 @@ If you skip automatic configuration, detailed setup instructions will be display
   "mcpServers": {
     "payments-mcp": {
       "command": "node",
-      "args": ["~/.payments-mcp/bundle.js"]
+      "args": ["/Users/your-home-dir/.payments-mcp/bundle.js"]
     }
   }
 }
@@ -101,112 +86,16 @@ npx @coinbase/payments-mcp install --verbose
 
 | Client | Value | Description | Auto-Config |
 |------|-------|-------------|-------------|
-| Claude Desktop | `claude` | Claude Desktop application | ✅ File-based |
-| Claude Code | `claude-code` | Claude Code CLI tool | ✅ CLI-based |
-| Codex CLI | `codex` | OpenAI Codex CLI tool | ✅ CLI-based |
-| Gemini CLI | `gemini` | Google Gemini CLI tool | ✅ CLI-based |
+| Claude Desktop | `claude` | Claude Desktop application | ✅ |
+| Claude Code | `claude-code` | Claude Code CLI tool | ✅ |
+| Codex CLI | `codex` | OpenAI Codex CLI tool | ✅ |
+| Gemini CLI | `gemini` | Google Gemini CLI tool | ✅ |
 | Other | `other` | Other stdio-compatible MCP clients | Manual only |
-
-**Auto-Config Support**:
-- ✅ **File-based**: Automatically creates/updates JSON configuration file
-- ✅ **CLI-based**: Executes the client's native CLI configuration command
-- **Manual only**: Manual configuration required (instructions provided after installation)
 
 ### File Locations
 
 - **Installation Directory**: `~/.payments-mcp/`
 - **Logs**: Displayed in terminal (use `--verbose` for detailed logs)
-
-## How It Works
-
-The installer orchestrates a multi-step process using its layered architecture:
-
-### Installation Workflow
-
-```
-CLI Command → Orchestrator  →  Services →  Utilities
-     ↓             ↓              ↓           ↓
-[parse args] → [coordinate] → [execute] → [foundation]
-```
-
-**Detailed Flow**:
-
-1. **CLI Processing** (`cli.ts`)
-   - Commander.js parses command and options
-   - Creates Logger with verbose setting
-   - Instantiates PaymentsMCPInstaller
-   - Calls appropriate method (install/status/uninstall)
-
-2. **Pre-flight Checks** (Orchestrator → InstallService → PathUtils)
-   - Verify Node.js executable availability
-   - Check npm command accessibility  
-   - Test network connectivity to download server
-
-3. **Version Analysis** (Orchestrator → VersionService → HttpUtils)
-   - Read local package.json using FileUtils
-   - Fetch remote version from API using HttpUtils
-   - Compare versions with semver logic
-   - Determine if update is needed
-
-4. **Download Phase** (Orchestrator → DownloadService → HttpUtils/FileUtils)
-   - Download ZIP package with progress tracking
-   - Validate download integrity
-   - Securely extract with path sanitization
-   - Cleanup temporary download files
-
-5. **Installation Phase** (Orchestrator → InstallService → PathUtils)
-   - Execute `npm install` in extracted directory
-   - Run electron installer if available
-   - Verify installation success
-
-6. **MCP Client Selection** (Orchestrator → Interactive Prompt)
-   - Prompt user to select their MCP client (or use --client flag)
-   - Support for Claude Desktop, Claude Code, Codex CLI, Gemini CLI, and other clients
-   
-7. **Configuration** (Orchestrator → ConfigService → PathUtils)
-   - Generate MCP server config for selected MCP client
-   - Display client-specific setup instructions
-   - Provide config file locations and troubleshooting information
-
-## Publishing New Versions
-
-This project uses a standard tag-based release workflow. To publish a new version:
-
-### 1. Bump the version
-
-Use npm's built-in version command to update `package.json` and create a git tag:
-
-```bash
-# For bug fixes (1.0.0 → 1.0.1)
-npm version patch
-
-# For new features (1.0.0 → 1.1.0)
-npm version minor
-
-# For breaking changes (1.0.0 → 2.0.0)
-npm version major
-```
-
-This automatically:
-- Updates `package.json` and `package-lock.json`
-- Creates a git commit with the version change
-- Creates a git tag (e.g., `v1.0.1`)
-
-### 2. Push the tag
-
-```bash
-git push && git push --tags
-```
-
-### 3. Automatic deployment
-
-Once the tag is pushed, the GitHub Actions workflow will automatically:
-- Run tests and linting
-- Build the project
-- Verify the version matches the tag
-- Publish to NPM with provenance
-
-**Note**: The workflow only triggers on tags matching the pattern `v*.*.*` (e.g., `v1.0.0`, `v2.1.3`).
 
 ## Troubleshooting
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -3,16 +3,10 @@ module.exports = {
   testEnvironment: 'node',
   roots: ['<rootDir>/src'],
   testMatch: ['**/__tests__/**/*.ts', '**/?(*.)+(spec|test).ts'],
-  collectCoverageFrom: [
-    'src/**/*.ts',
-    '!src/**/*.d.ts',
-    '!src/cli.ts',
-  ],
+  collectCoverageFrom: ['src/**/*.ts', '!src/**/*.d.ts', '!src/cli.ts'],
   coverageDirectory: 'coverage',
   coverageReporters: ['text', 'lcov'],
-  globals: {
-    'ts-jest': {
-      isolatedModules: true,
-    },
+  transform: {
+    '^.+\\.ts$': ['ts-jest', {}],
   },
 };

--- a/src/services/configService.ts
+++ b/src/services/configService.ts
@@ -1,5 +1,6 @@
 import chalk from 'chalk';
 import fs from 'fs-extra';
+import os from 'os';
 import path from 'path';
 import { exec } from 'child_process';
 import { promisify } from 'util';
@@ -120,7 +121,7 @@ export class ConfigService {
       return undefined;
     }
 
-    const homeDir = require('os').homedir();
+    const homeDir = os.homedir();
     return clientInfo.configPath(homeDir) || undefined;
   }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,7 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
+    "isolatedModules": true,
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,


### PR DESCRIPTION
## What changed? Why?

**1. Tag-Based Release Workflow** (`publish_npm_payments_mcp.yml`)
- Changed trigger from manual `workflow_dispatch` to automatic `push.tags`
- Workflow now triggers automatically when version tags (e.g., `v1.0.0`) are pushed
- Added version verification step to ensure `package.json` matches the git tag
- Removed manual version input - version is extracted from tag instead

**2. Automated PR Verification** (`dry_run_npm_payments_mcp.yml`)
- Renamed to "Verify Package" workflow
- Now runs automatically on all PRs to `main`
- Verifies package can be published without actually publishing
- Provides release instructions in workflow summary

### New Release Process

```bash
npm version patch    # Updates package.json, creates commit & tag
git push --follow-tags   # Triggers automatic publish to NPM
```