### PR TITLE
chore: bump version to 1.0.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@coinbase/payments-mcp",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@coinbase/payments-mcp",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "license": "Apache-2.0",
       "dependencies": {
         "axios": "^1.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/payments-mcp",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "NPX installer for Payments MCP",
   "main": "dist/cli.js",
   "bin": {


### PR DESCRIPTION
## What changed? Why?

Bump version to 1.0.4
